### PR TITLE
Add support for functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "jsonpath": "^0.2.2",
+    "lodash": "^4.16.3",
     "merge": "^1.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import jp from 'jsonpath';
 import merge from 'merge';
+import flatMap from 'lodash/flatMap';
+import uniq from 'lodash/uniq';
 
 class Ref {
   constructor(path) {
@@ -75,52 +77,9 @@ var _applyToPath = function(obj, path, val) {
   }
 };
 
-var doConcat = function(obj, args) {
-  var arr = [];
-
-  for (var i = 0, len = args.length; i < len; i++) {
-    var res = jp.query(obj, args[i]);
-
-    if (res.length) {
-      arr = arr.concat(res);
-    }
-  }
-
-  return arr
-}
-
-var _contains = function(arr, obj) {
-  for (var i = 0, len = arr.length; i < len; i++) {
-    if (arr[i] == obj) {
-      return true
-    }
-  }
-
-  return false;
-}
-
-var doUniq = function(obj, args) {
-  var arr = doConcat(obj, args);
-
-  if (arr.length) {
-    var index = [],
-        len = arr.length;
-
-    for (var i = 0; i < len; i++) {
-      if (!_contains(index, arr[i])) {
-        index.push(arr[i]);
-      }
-    }
-
-    arr = index;
-  }
-
-  return arr
-}
-
 const FUNCTIONS = {
-  'concat': doConcat,
-  'uniq':   doUniq,
+  'concat': (obj, args) => flatMap(args, (arg) => jp.query(obj, arg)),
+  'uniq':   (obj, args) => uniq(flatMap(args, (arg) => jp.query(obj, arg)))
 };
 
 const EXPRESSION_PATTERN = /^([^\$][\w]+)\((.*)\)$/;

--- a/test/index.js
+++ b/test/index.js
@@ -3,7 +3,7 @@ import {expect} from 'chai';
 
 describe('json', () => {
   describe('get', () => {
-    var fixture = {'test': 1};
+    var fixture = {'test': 1, 'test2': 2};
 
     it('should get stuff by path', () => {
       expect(json.get(fixture, '$.test')).to.equal(1);
@@ -15,6 +15,18 @@ describe('json', () => {
 
     it('returns nothing when the path is empty and there is no default', () => {
       expect(json.get(fixture, '$.nothing')).to.be.undefined;
+    });
+
+    it('should concat results when using the concat function', () => {
+      expect(json.get(fixture, 'concat($.test, $.test2)')).to.eql([1, 2]);
+    });
+
+    it('should concat and uniquify results when using the uniq function', () => {
+      expect(json.get(fixture, 'uniq($.test, $.test2)')).to.eql([1, 2]);
+    });
+
+    it('should apply functions no matter the case of the name', () => {
+      expect(json.get(fixture, 'UNIQ($.test, $.test2)')).to.eql([1, 2]);
     });
   });
 


### PR DESCRIPTION
This pull request extends the query syntax to apply functions to the result set, allowing the user to query and perform multiple operations at once. This implementation is very naive but gets this concept up off the ground.
