### PR TITLE
Add support for `derefRecursive`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist
 /node_modules
+*.sw[onp]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "jsonpath": "^0.2.2",
-    "lodash": "^4.16.3",
+    "lodash": "4.15.0",
     "merge": "^1.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -147,17 +147,19 @@ const get = (obj, path, def) => {
   return def;
 };
 
-const derefRecursive = (obj, vals) => {
+const derefRecursive = (obj, vals, resolver) => {
   const updated = {};
+
+  if (!resolver) resolver = v => v;
 
   const loop = (o) => {
     Object.keys(o).forEach((key) => {
       if (_isObject(o[key])) {
         loop(o[key]);
       } else if (typeof o[key] === 'string' && o[key].indexOf('$.') === 0) {
-        //const path = resolvePath(o[key], componentId);
+        const path = resolver(o[key])
 
-        updated[key] = get(vals, o[key]);
+        updated[key] = get(vals, path);
       } else {
         updated[key] = o[key];
       }

--- a/src/index.js
+++ b/src/index.js
@@ -16,22 +16,18 @@ class Ref {
  * @param  {Object} obj  The object to setup.
  * @param  {String} path The path to initialize.
  */
-var _initPath = function(obj, path) {
-  var idx = path.lastIndexOf('.'),
-      prefix = path.substr(0, idx),
-      suffix = path.substr(idx + 1),
-      paths;
-
-  paths = jp.paths(obj, prefix);
+const _initPath = (obj, path) => {
+  const idx = path.lastIndexOf('.');
+  const prefix = path.substr(0, idx);
+  const suffix = path.substr(idx + 1);
+  let paths = jp.paths(obj, prefix);
 
   if (!paths.length) {
     _initPath(obj, prefix);
     paths = jp.paths(obj, prefix);
   }
 
-  paths.forEach((p) => {
-    return _applyToPath(obj, p.slice(1), _createObj(suffix, null));
-  });
+  paths.forEach(p => _applyToPath(obj, p.slice(1), _createObj(suffix, null)));
 };
 
 /**
@@ -40,7 +36,7 @@ var _initPath = function(obj, path) {
  * @param  {Object} val  Value for the attribute.
  * @return {Object}      An object with one attribute.
  */
-var _createObj = function(name, val) {
+const _createObj = (name, val) => {
   var o = {};
 
   o[name] = val;
@@ -54,7 +50,7 @@ var _createObj = function(name, val) {
  * @param  {Array} path A resolved path from jsonpath.
  * @param  {Object} val An object to apply to the end.
  */
-var _applyToPath = function(obj, path, val) {
+const _applyToPath = (obj, path, val) => {
   var pos = obj,
       len = path.length,
       key;
@@ -78,8 +74,8 @@ var _applyToPath = function(obj, path, val) {
 };
 
 const FUNCTIONS = {
-  'concat': (obj, args) => flatMap(args, (arg) => jp.query(obj, arg)),
-  'uniq':   (obj, args) => uniq(flatMap(args, (arg) => jp.query(obj, arg)))
+  concat: (obj, args) => flatMap(args, (arg) => jp.query(obj, arg)),
+  uniq:   (obj, args) => uniq(flatMap(args, (arg) => jp.query(obj, arg)))
 };
 
 const EXPRESSION_PATTERN = /^([^\$][\w]+)\((.*)\)$/;
@@ -91,7 +87,7 @@ const EXPRESSION_PATTERN = /^([^\$][\w]+)\((.*)\)$/;
  * @param  {String} path A path to query against.
  * @return {boolean}  A boolean representing if the path is in the obj.
  */
-var has = function(obj, path) {
+const has = (obj, path) => {
   var res = jp.query(obj, path);
 
   return res.length > 0;
@@ -105,7 +101,7 @@ var has = function(obj, path) {
  * @param  {Object} def  The default to return in case the query comes up empty.
  * @return {Object}      The value at path within obj or the default.
  */
-var get = function(obj, path, def) {
+const get = (obj, path, def) => {
   // TODO: This is a really nieve implementation of functions--we want to be
   // able to support much more complicated expressions one day--but this will
   // work for now.
@@ -155,8 +151,8 @@ var get = function(obj, path, def) {
  * @param  {String} path A path to query against.
  * @param  {Object} val  The value to set at the path.
  */
-var set = function(obj, path, val) {
-  var res = jp.apply(obj, path, () => val);
+const set = (obj, path, val) => {
+  const res = jp.apply(obj, path, () => val);
 
   if (!res.length) {
     _initPath(obj, path);
@@ -170,7 +166,7 @@ var set = function(obj, path, val) {
  * @param  {String} path The path to query for a value for.
  * @return {Ref}         A new instance of Ref
  */
-var ref = function(path) {
+const ref = (path) => {
   return new Ref(path);
 };
 
@@ -179,7 +175,7 @@ var ref = function(path) {
  * @param  {Object} o Some object to test.
  * @return {boolean}  True if o is of type Ref, false otherwise.
  */
-var isRef = function(o) {
+const isRef = (o) => {
   if (!o) {
     return false;
   }
@@ -188,9 +184,9 @@ var isRef = function(o) {
 };
 
 module.exports = {
-  set: set,
-  has: has,
-  get: get,
-  ref: ref,
-  isRef: isRef
+  set,
+  has,
+  get,
+  ref,
+  isRef,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -78,8 +78,13 @@ const _applyToPath = (obj, path, val) => {
 };
 
 const FUNCTIONS = {
+  values: (obj, args) => {
+    const values = get(obj, args[0]);
+
+    return Object.keys(values).map(key => values[key]);
+  },
   concat: (obj, args) => flatMap(args, (arg) => jp.query(obj, arg)),
-  uniq:   (obj, args) => uniq(flatMap(args, (arg) => jp.query(obj, arg)))
+  uniq: (obj, args) => uniq(flatMap(args, (arg) => jp.query(obj, arg)))
 };
 
 const EXPRESSION_PATTERN = /^([^\$][\w]+)\((.*)\)$/;
@@ -152,11 +157,14 @@ const derefRecursive = (obj, vals, resolver) => {
 
   if (!resolver) resolver = v => v;
 
+  const isRef = (ref) =>
+    typeof ref === 'string' && (ref.indexOf('$') === 0 || ref.match(EXPRESSION_PATTERN));
+
   const loop = (o) => {
     Object.keys(o).forEach((key) => {
       if (_isObject(o[key])) {
         loop(o[key]);
-      } else if (typeof o[key] === 'string' && o[key].indexOf('$.') === 0) {
+      } else if (isRef(o[key])) {
         const path = resolver(o[key])
 
         updated[key] = get(vals, path);

--- a/test/index.js
+++ b/test/index.js
@@ -40,6 +40,10 @@ describe('json', () => {
     it('should apply functions no matter the case of the name', () => {
       expect(json.get(fixture, 'UNIQ($.test, $.test2)')).to.eql([1, 2]);
     });
+
+    it('should allow the user to query an object values', () => {
+      expect(json.get(fixture, 'VALUES($)')).to.eql([1, 2]);
+    });
   });
 
   describe('derefRecursive', () => {
@@ -74,6 +78,15 @@ describe('json', () => {
       });
 
       expect(value).to.eql({ firstName: 'Steve' });
+    });
+
+    it('should recognize values with expressions', () => {
+      const fixtureObj = { names: 'VALUES($.names)' };
+      const fixtureVal = { names: { person1: 'Steve', person2: 'Joe' } };
+
+      const value = json.derefRecursive(fixtureObj, fixtureVal);
+
+      expect(value).to.eql({ names: ['Steve', 'Joe'] });
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -15,7 +15,7 @@ describe('json', () => {
   });
 
   describe('get', () => {
-    var fixture = {'test': 1, 'test2': 2};
+    var fixture = { 'test': 1, 'test2': 2 };
 
     it('should get stuff by path', () => {
       expect(json.get(fixture, '$.test')).to.equal(1);
@@ -39,6 +39,30 @@ describe('json', () => {
 
     it('should apply functions no matter the case of the name', () => {
       expect(json.get(fixture, 'UNIQ($.test, $.test2)')).to.eql([1, 2]);
+    });
+  });
+
+  describe('derefRecursive', () => {
+    it('should recursively deref refs in an object tree', () => {
+      const fixtureObj = {
+        names: '$.names',
+        months: ['May', 'June', 'July'],
+        ages: '$.people.ages'
+      };
+
+      const fixtureVal = {
+        names: ['Steve', 'Bob'],
+        people: {
+          ages: [24, 12],
+        },
+      };
+
+      const value = json.derefRecursive(fixtureObj, fixtureVal);
+      expect(value).to.eql({
+        names: ['Steve', 'Bob'],
+        months: ['May', 'June', 'July'],
+        ages: [24, 12],
+      });
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -44,7 +44,7 @@ describe('json', () => {
 
   describe('set', () => {
     it('should set values that already exist', () => {
-      var obj = {'test': 1};
+      var obj = { 'test': 1 };
 
       json.set(obj, '$.test', 2);
       expect(obj.test).to.equal(2);
@@ -73,14 +73,14 @@ describe('json', () => {
     });
 
     it('should replace arrays when they are updated', () => {
-      var obj = {test: [1, 2]};
+      var obj = { test: [1, 2] };
 
       json.set(obj, '$.test', [1]);
       expect(obj.test.length).to.equal(1);
     });
 
     it('should replace arrays when they are updated', () => {
-      var obj = {test: [1]};
+      var obj = { test: [1] };
 
       json.set(obj, '$.test', [2, 3, 4]);
       expect(obj.test.length).to.equal(3);

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,17 @@ describe('json', () => {
         ages: [24, 12],
       });
     });
+
+    it('should allow the user to supply a callback for resolving the paths', () => {
+      const fixtureObj = { firstName: '$.NAME.name' };
+      const fixtureVal = { steve: { name: 'Steve' } };
+
+      const value = json.derefRecursive(fixtureObj, fixtureVal, (path) => {
+        return path.replace('NAME', 'steve');
+      });
+
+      expect(value).to.eql({ firstName: 'Steve' });
+    });
   });
 
   describe('set', () => {


### PR DESCRIPTION
Given an object and an object of values, recursively derefs the first object with the values in the second one.